### PR TITLE
Update validateVolume in k8s_validation to include hostPath volumes

### DIFF
--- a/pkg/apis/serving/k8s_validation.go
+++ b/pkg/apis/serving/k8s_validation.go
@@ -161,6 +161,10 @@ func validateVolume(ctx context.Context, volume corev1.Volume) *apis.FieldError 
 		specified = append(specified, "persistentVolumeClaim")
 	}
 
+	if vs.HostPath != nil {
+		specified = append(specified, "hostPath")
+	}
+
 	if len(specified) == 0 {
 		fieldPaths := []string{"secret", "configMap", "projected"}
 		cfg := config.FromContextOrDefaults(ctx)
@@ -169,6 +173,9 @@ func validateVolume(ctx context.Context, volume corev1.Volume) *apis.FieldError 
 		}
 		if cfg.Features.PodSpecPersistentVolumeClaim == config.Enabled {
 			fieldPaths = append(fieldPaths, "persistentVolumeClaim")
+		}
+		if cfg.Features.PodSpecVolumesHostPath == config.Enabled {
+			fieldPaths = append(fieldPaths, "hostPath")
 		}
 		errs = errs.Also(apis.ErrMissingOneOf(fieldPaths...))
 	} else if len(specified) > 1 {


### PR DESCRIPTION
Adding a hostPath Volume to Service causes the following error

```
Error from server (BadRequest): error when creating "svc.yaml": admission webhook "validation.webhook.serving.knative.dev" denied the request: validation failed: expected exactly one, got neither: spec.template.spec.volumes[0].configMap, spec.template.spec.volumes[0].emptyDir, spec.template.spec.volumes[0].projected, spec.template.spec.volumes[0].secret
```

This failure is happening when validating the Volume on the service. This change allows for hostPath volumes but added it when validating volumes

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Update validateVolume to include hostPath volumes

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

